### PR TITLE
import ReadableStream (not in global scope)

### DIFF
--- a/typings/promise/index.d.ts
+++ b/typings/promise/index.d.ts
@@ -1,4 +1,5 @@
 import * as resp from "../response";
+import ReadableStream = NodeJS.ReadableStream;
 
 declare function simplegit(basePath?: string): simplegit.SimpleGit;
 


### PR DESCRIPTION
Fixes an issue when using the type definition where `ReadableStream` is not known (it's within the `NodeJS` namespace).